### PR TITLE
Addition of 'verenigingsloket' page

### DIFF
--- a/app/config/custom-inflector-rules.js
+++ b/app/config/custom-inflector-rules.js
@@ -82,3 +82,12 @@ inflector.irregular(
   'installatievergadering-synchronization-status',
   'installatievergadering-synchronization-statuses',
 );
+
+// Hackathon
+inflector.irregular('case', 'cases');
+inflector.irregular('event', 'events');
+inflector.irregular('submission', 'submissions');
+inflector.irregular('identificator', 'identificatoren');
+inflector.irregular('location', 'locations');
+inflector.irregular('timeframe', 'timeframes');
+inflector.irregular('organization', 'organizations');

--- a/app/controllers/inbox/verenigingsloket.js
+++ b/app/controllers/inbox/verenigingsloket.js
@@ -1,17 +1,9 @@
-import Controller from '@ember/controller';
 import { service } from '@ember/service';
-import { action } from '@ember/object';
+import Controller from '@ember/controller';
 import { trackedFunction } from 'ember-resources/util/function';
 
-export default class InboxController extends Controller {
-  @service currentSession; //used in template
-  @service session;
+export default class InboxVerenigingsloketController extends Controller {
   @service store;
-  @action
-  logout() {
-    this.session.invalidate();
-  }
-
   newSubmissionCount = trackedFunction(this, async () => {
     return this.store.count('submission', {
       filter: {

--- a/app/controllers/inbox/verenigingsloket/behandeld.js
+++ b/app/controllers/inbox/verenigingsloket/behandeld.js
@@ -15,7 +15,7 @@ export default class VerenigingsloketBehandeldController extends Controller {
   @tracked filter;
   @tracked page = 0;
   @tracked pageSize = 10;
-  @tracked sort = '-created-on';
+  @tracked sort = '-date';
 
   data = trackedFunction(this, async () => {
     return this.store.query('submission', {

--- a/app/controllers/inbox/verenigingsloket/behandeld.js
+++ b/app/controllers/inbox/verenigingsloket/behandeld.js
@@ -9,6 +9,7 @@ const SEARCH_DEBOUNCE_MS = 300;
 
 export default class VerenigingsloketBehandeldController extends Controller {
   @service verenigingsloket;
+  @service store;
 
   queryParams = ['filter', 'page', 'pageSize', 'sort'];
   @tracked filter;

--- a/app/controllers/inbox/verenigingsloket/behandeld.js
+++ b/app/controllers/inbox/verenigingsloket/behandeld.js
@@ -21,12 +21,16 @@ export default class VerenigingsloketBehandeldController extends Controller {
     return this.store.query('submission', {
       filter: {
         ':has-no:editor-document': false,
-        title: this.filter,
         'editor-document': {
           'document-container': {
             status: {
               ':id:': PUBLISHED_STATUS_ID,
             },
+          },
+        },
+        case: {
+          event: {
+            description: this.filter,
           },
         },
       },

--- a/app/controllers/inbox/verenigingsloket/behandeld.js
+++ b/app/controllers/inbox/verenigingsloket/behandeld.js
@@ -22,7 +22,13 @@ export default class VerenigingsloketBehandeldController extends Controller {
       filter: {
         ':has-no:editor-document': false,
         title: this.filter,
-        'editor-document.document-container.status:id:': PUBLISHED_STATUS_ID,
+        'editor-document': {
+          'document-container': {
+            status: {
+              ':id:': PUBLISHED_STATUS_ID,
+            },
+          },
+        },
       },
       sort: this.sort,
       page: {

--- a/app/controllers/inbox/verenigingsloket/behandeld.js
+++ b/app/controllers/inbox/verenigingsloket/behandeld.js
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { trackedFunction } from 'ember-resources/util/function';
 import { service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { PUBLISHED_STATUS_ID } from '../../../utils/constants';
 
 const SEARCH_DEBOUNCE_MS = 300;
 
@@ -16,17 +17,19 @@ export default class VerenigingsloketBehandeldController extends Controller {
   @tracked sort = '-created-on';
 
   data = trackedFunction(this, async () => {
-    // return this.store.query('aanvraag-verenigingsloket', {
-    //   filter: {
-    //     ':exact:status': 'behandeld',
-    //     title: this.filter,
-    //   },
-    //   sort: this.sort,
-    //   page: {
-    //     number: this.page,
-    //     size: this.pageSize,
-    //   },
-    // });
+    return this.store.query('submission', {
+      filter: {
+        ':has-no:editor-document': false,
+        title: this.filter,
+        'editor-document.document-container.status:id:': PUBLISHED_STATUS_ID,
+      },
+      sort: this.sort,
+      page: {
+        number: this.page,
+        size: this.pageSize,
+      },
+      include: ['applicant', 'case', 'case.event', 'editor-document'].join(','),
+    });
     const result = await this.verenigingsloket.fetch.perform({
       title: this.filter,
       status: 'behandeld',

--- a/app/controllers/inbox/verenigingsloket/behandeld.js
+++ b/app/controllers/inbox/verenigingsloket/behandeld.js
@@ -1,0 +1,42 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { trackedFunction } from 'ember-resources/util/function';
+import { service } from '@ember/service';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export default class VerenigingsloketBehandeldController extends Controller {
+  @service verenigingsloket;
+
+  queryParams = ['filter', 'page', 'pageSize', 'sort'];
+  @tracked filter;
+  @tracked page = 0;
+  @tracked pageSize = 10;
+  @tracked sort = '-created-on';
+
+  data = trackedFunction(this, async () => {
+    // return this.store.query('aanvraag-verenigingsloket', {
+    //   filter: {
+    //     ':exact:status': 'behandeld',
+    //     title: this.filter,
+    //   },
+    //   sort: this.sort,
+    //   page: {
+    //     number: this.page,
+    //     size: this.pageSize,
+    //   },
+    // });
+    const result = await this.verenigingsloket.fetch.perform({
+      title: this.filter,
+      status: 'behandeld',
+    });
+    return result;
+  });
+
+  updateFilter = restartableTask(async (event) => {
+    const value = event.target.value;
+    await timeout(SEARCH_DEBOUNCE_MS);
+    this.filter = value;
+  });
+}

--- a/app/controllers/inbox/verenigingsloket/in-behandeling.js
+++ b/app/controllers/inbox/verenigingsloket/in-behandeling.js
@@ -3,7 +3,10 @@ import { tracked } from '@glimmer/tracking';
 import { trackedFunction } from 'ember-resources/util/function';
 import { service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
-
+import {
+  DRAFT_STATUS_ID,
+  PLANNED_STATUS_ID,
+} from 'frontend-gelinkt-notuleren/utils/constants';
 const SEARCH_DEBOUNCE_MS = 300;
 
 export default class VerenigingsloketInBehandelingController extends Controller {
@@ -16,17 +19,22 @@ export default class VerenigingsloketInBehandelingController extends Controller 
   @tracked sort = '-created-on';
 
   data = trackedFunction(this, async () => {
-    // return this.store.query('aanvraag-verenigingsloket', {
-    //   filter: {
-    //     ':exact:status': 'in-behandeling',
-    //     title: this.filter,
-    //   },
-    //   sort: this.sort,
-    //   page: {
-    //     number: this.page,
-    //     size: this.pageSize,
-    //   },
-    // });
+    return this.store.query('submission', {
+      filter: {
+        ':has-no:editor-document': false,
+        title: this.filter,
+        'editor-document.document-container.status:id:': [
+          DRAFT_STATUS_ID,
+          PLANNED_STATUS_ID,
+        ].join(','),
+      },
+      sort: this.sort,
+      page: {
+        number: this.page,
+        size: this.pageSize,
+      },
+      include: ['applicant', 'case', 'case.event', 'editor-document'].join(','),
+    });
     const result = await this.verenigingsloket.fetch.perform({
       title: this.filter,
       status: 'in-behandeling',

--- a/app/controllers/inbox/verenigingsloket/in-behandeling.js
+++ b/app/controllers/inbox/verenigingsloket/in-behandeling.js
@@ -24,10 +24,13 @@ export default class VerenigingsloketInBehandelingController extends Controller 
       filter: {
         ':has-no:editor-document': false,
         title: this.filter,
-        'editor-document.document-container.status:id:': [
-          DRAFT_STATUS_ID,
-          PLANNED_STATUS_ID,
-        ].join(','),
+        'editor-document': {
+          'document-container': {
+            status: {
+              ':id:': [DRAFT_STATUS_ID, PLANNED_STATUS_ID].join(','),
+            },
+          },
+        },
       },
       sort: this.sort,
       page: {

--- a/app/controllers/inbox/verenigingsloket/in-behandeling.js
+++ b/app/controllers/inbox/verenigingsloket/in-behandeling.js
@@ -11,6 +11,7 @@ const SEARCH_DEBOUNCE_MS = 300;
 
 export default class VerenigingsloketInBehandelingController extends Controller {
   @service verenigingsloket;
+  @service store;
 
   queryParams = ['filter', 'page', 'pageSize', 'sort'];
   @tracked filter;

--- a/app/controllers/inbox/verenigingsloket/in-behandeling.js
+++ b/app/controllers/inbox/verenigingsloket/in-behandeling.js
@@ -23,12 +23,16 @@ export default class VerenigingsloketInBehandelingController extends Controller 
     return this.store.query('submission', {
       filter: {
         ':has-no:editor-document': false,
-        title: this.filter,
         'editor-document': {
           'document-container': {
             status: {
               ':id:': [DRAFT_STATUS_ID, PLANNED_STATUS_ID].join(','),
             },
+          },
+        },
+        case: {
+          event: {
+            description: this.filter,
           },
         },
       },

--- a/app/controllers/inbox/verenigingsloket/in-behandeling.js
+++ b/app/controllers/inbox/verenigingsloket/in-behandeling.js
@@ -17,7 +17,7 @@ export default class VerenigingsloketInBehandelingController extends Controller 
   @tracked filter;
   @tracked page = 0;
   @tracked pageSize = 10;
-  @tracked sort = '-created-on';
+  @tracked sort = '-date';
 
   data = trackedFunction(this, async () => {
     return this.store.query('submission', {

--- a/app/controllers/inbox/verenigingsloket/in-behandeling.js
+++ b/app/controllers/inbox/verenigingsloket/in-behandeling.js
@@ -1,0 +1,42 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { trackedFunction } from 'ember-resources/util/function';
+import { service } from '@ember/service';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export default class VerenigingsloketInBehandelingController extends Controller {
+  @service verenigingsloket;
+
+  queryParams = ['filter', 'page', 'pageSize', 'sort'];
+  @tracked filter;
+  @tracked page = 0;
+  @tracked pageSize = 10;
+  @tracked sort = '-created-on';
+
+  data = trackedFunction(this, async () => {
+    // return this.store.query('aanvraag-verenigingsloket', {
+    //   filter: {
+    //     ':exact:status': 'in-behandeling',
+    //     title: this.filter,
+    //   },
+    //   sort: this.sort,
+    //   page: {
+    //     number: this.page,
+    //     size: this.pageSize,
+    //   },
+    // });
+    const result = await this.verenigingsloket.fetch.perform({
+      title: this.filter,
+      status: 'in-behandeling',
+    });
+    return result;
+  });
+
+  updateFilter = restartableTask(async (event) => {
+    const value = event.target.value;
+    await timeout(SEARCH_DEBOUNCE_MS);
+    this.filter = value;
+  });
+}

--- a/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
@@ -21,7 +21,11 @@ export default class VerenigingsloketTeBehandelenAWVController extends Controlle
     return this.store.query('submission', {
       filter: {
         ':has-no:editor-document': true,
-        title: this.filter,
+        case: {
+          event: {
+            description: this.filter,
+          },
+        },
       },
       sort: this.sort,
       page: {

--- a/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
@@ -14,7 +14,7 @@ export default class VerenigingsloketTeBehandelenAWVController extends Controlle
   @tracked filter;
   @tracked page = 0;
   @tracked pageSize = 10;
-  @tracked sort = '-created-on';
+  @tracked sort = '-date';
 
   data = trackedFunction(this, async () => {
     // TODO: adjust this query

--- a/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
@@ -16,17 +16,19 @@ export default class VerenigingsloketTeBehandelenAWVController extends Controlle
   @tracked sort = '-created-on';
 
   data = trackedFunction(this, async () => {
-    // return this.store.query('aanvraag-verenigingsloket', {
-    //   filter: {
-    //     ':exact:status': 'te-behandelen-awv',
-    //     title: this.filter,
-    //   },
-    //   sort: this.sort,
-    //   page: {
-    //     number: this.page,
-    //     size: this.pageSize,
-    //   },
-    // });
+    // TODO: adjust this query
+    return this.store.query('submission', {
+      filter: {
+        ':has-no:editor-document': true,
+        title: this.filter,
+      },
+      sort: this.sort,
+      page: {
+        number: this.page,
+        size: this.pageSize,
+      },
+      include: ['applicant', 'case', 'case.event'].join(','),
+    });
     const result = await this.verenigingsloket.fetch.perform({
       title: this.filter,
       status: 'te-behandelen',

--- a/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
@@ -8,6 +8,7 @@ const SEARCH_DEBOUNCE_MS = 300;
 
 export default class VerenigingsloketTeBehandelenAWVController extends Controller {
   @service verenigingsloket;
+  @service store;
 
   queryParams = ['filter', 'page', 'pageSize', 'sort'];
   @tracked filter;

--- a/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen-awv.js
@@ -1,0 +1,42 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { trackedFunction } from 'ember-resources/util/function';
+import { service } from '@ember/service';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export default class VerenigingsloketTeBehandelenAWVController extends Controller {
+  @service verenigingsloket;
+
+  queryParams = ['filter', 'page', 'pageSize', 'sort'];
+  @tracked filter;
+  @tracked page = 0;
+  @tracked pageSize = 10;
+  @tracked sort = '-created-on';
+
+  data = trackedFunction(this, async () => {
+    // return this.store.query('aanvraag-verenigingsloket', {
+    //   filter: {
+    //     ':exact:status': 'te-behandelen-awv',
+    //     title: this.filter,
+    //   },
+    //   sort: this.sort,
+    //   page: {
+    //     number: this.page,
+    //     size: this.pageSize,
+    //   },
+    // });
+    const result = await this.verenigingsloket.fetch.perform({
+      title: this.filter,
+      status: 'te-behandelen',
+    });
+    return result;
+  });
+
+  updateFilter = restartableTask(async (event) => {
+    const value = event.target.value;
+    await timeout(SEARCH_DEBOUNCE_MS);
+    this.filter = value;
+  });
+}

--- a/app/controllers/inbox/verenigingsloket/te-behandelen.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen.js
@@ -20,7 +20,11 @@ export default class VerenigingsloketTeBehandelenController extends Controller {
     return this.store.query('submission', {
       filter: {
         ':has-no:editor-document': true,
-        title: this.filter,
+        case: {
+          event: {
+            description: this.filter,
+          },
+        },
       },
       sort: this.sort,
       page: {

--- a/app/controllers/inbox/verenigingsloket/te-behandelen.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen.js
@@ -14,7 +14,7 @@ export default class VerenigingsloketTeBehandelenController extends Controller {
   @tracked filter;
   @tracked page = 0;
   @tracked pageSize = 10;
-  @tracked sort = '-created-on';
+  @tracked sort = '-date';
 
   data = trackedFunction(this, async () => {
     return this.store.query('submission', {

--- a/app/controllers/inbox/verenigingsloket/te-behandelen.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen.js
@@ -16,17 +16,18 @@ export default class VerenigingsloketTeBehandelenController extends Controller {
   @tracked sort = '-created-on';
 
   data = trackedFunction(this, async () => {
-    // return this.store.query('aanvraag-verenigingsloket', {
-    //   filter: {
-    //     ':exact:status': 'te-behandelen',
-    //     title: this.filter,
-    //   },
-    //   sort: this.sort,
-    //   page: {
-    //     number: this.page,
-    //     size: this.pageSize,
-    //   },
-    // });
+    return this.store.query('submission', {
+      filter: {
+        ':has-no:editor-document': true,
+        title: this.filter,
+      },
+      sort: this.sort,
+      page: {
+        number: this.page,
+        size: this.pageSize,
+      },
+      include: ['applicant', 'case', 'case.event'].join(','),
+    });
     const result = await this.verenigingsloket.fetch.perform({
       title: this.filter,
       status: 'te-behandelen',

--- a/app/controllers/inbox/verenigingsloket/te-behandelen.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen.js
@@ -8,6 +8,7 @@ const SEARCH_DEBOUNCE_MS = 300;
 
 export default class VerenigingsloketTeBehandelenController extends Controller {
   @service verenigingsloket;
+  @service store;
 
   queryParams = ['filter', 'page', 'pageSize', 'sort'];
   @tracked filter;

--- a/app/controllers/inbox/verenigingsloket/te-behandelen.js
+++ b/app/controllers/inbox/verenigingsloket/te-behandelen.js
@@ -1,0 +1,42 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { trackedFunction } from 'ember-resources/util/function';
+import { service } from '@ember/service';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export default class VerenigingsloketTeBehandelenController extends Controller {
+  @service verenigingsloket;
+
+  queryParams = ['filter', 'page', 'pageSize', 'sort'];
+  @tracked filter;
+  @tracked page = 0;
+  @tracked pageSize = 10;
+  @tracked sort = '-created-on';
+
+  data = trackedFunction(this, async () => {
+    // return this.store.query('aanvraag-verenigingsloket', {
+    //   filter: {
+    //     ':exact:status': 'te-behandelen',
+    //     title: this.filter,
+    //   },
+    //   sort: this.sort,
+    //   page: {
+    //     number: this.page,
+    //     size: this.pageSize,
+    //   },
+    // });
+    const result = await this.verenigingsloket.fetch.perform({
+      title: this.filter,
+      status: 'te-behandelen',
+    });
+    return result;
+  });
+
+  updateFilter = restartableTask(async (event) => {
+    const value = event.target.value;
+    await timeout(SEARCH_DEBOUNCE_MS);
+    this.filter = value;
+  });
+}

--- a/app/models/aanvraag-verenigingsloket.js
+++ b/app/models/aanvraag-verenigingsloket.js
@@ -1,9 +1,0 @@
-import Model, { attr } from '@ember-data/model';
-
-export default class AanvraagVerenigingsloketModel extends Model {
-  @attr('string') title;
-  @attr('string') organizer;
-  @attr('string') status;
-  @attr('datetime') createdOn;
-  @attr('datetime') dueDate;
-}

--- a/app/models/aanvraag-verenigingsloket.js
+++ b/app/models/aanvraag-verenigingsloket.js
@@ -1,0 +1,9 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AanvraagVerenigingsloketModel extends Model {
+  @attr('string') title;
+  @attr('string') organizer;
+  @attr('string') status;
+  @attr('datetime') createdOn;
+  @attr('datetime') dueDate;
+}

--- a/app/models/case.js
+++ b/app/models/case.js
@@ -1,0 +1,8 @@
+import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
+
+export default class CaseModel extends Model {
+  @attr uri;
+
+  @belongsTo('event', { inverse: 'case', async: true }) event;
+  @hasMany('submission', { inverse: 'case', async: true }) submissions;
+}

--- a/app/models/event.js
+++ b/app/models/event.js
@@ -1,0 +1,10 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+
+export default class EventModel extends Model {
+  @attr uri;
+  @attr('string') description;
+
+  @hasMany('case', { inverse: 'event', async: true }) cases;
+  @hasMany('location', { inverse: 'event', async: true }) locations;
+  @hasMany('timeframe', { inverse: 'event', async: true }) timeframes;
+}

--- a/app/models/location.js
+++ b/app/models/location.js
@@ -1,0 +1,7 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class LocationModel extends Model {
+  @attr uri;
+
+  @belongsTo('event', { inverse: 'locations', async: true }) event;
+}

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -1,0 +1,8 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+
+export default class OrganizationModel extends Model {
+  @attr('string') uri;
+  @attr('string') name;
+
+  @hasMany('user', { inverse: 'organization', async: true }) users;
+}

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -1,4 +1,4 @@
-import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class SubmissionModel extends Model {
   @attr uri;

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -1,4 +1,4 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class SubmissionModel extends Model {
   @attr uri;
@@ -7,4 +7,5 @@ export default class SubmissionModel extends Model {
   @belongsTo('organization', { inverse: 'submissions', async: true }) applicant;
   @belongsTo('case', { inverse: 'submissions', async: true }) case;
   @belongsTo('bestuurseenheid') administrativeUnit;
+  @belongsTo('editor-document') editorDocument;
 }

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -1,0 +1,10 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class SubmissionModel extends Model {
+  @attr uri;
+  @attr('datetime') date;
+
+  @belongsTo('organization', { inverse: 'submissions', async: true }) applicant;
+  @belongsTo('case', { inverse: 'submissions', async: true }) case;
+  @belongsTo('bestuurseenheid') administrativeUnit;
+}

--- a/app/models/timeframe.js
+++ b/app/models/timeframe.js
@@ -1,6 +1,6 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
-export default class SubmissionModel extends Model {
+export default class TimeframeModel extends Model {
   @attr uri;
   @attr('datetime') start;
   @attr('datetime') end;

--- a/app/models/timeframe.js
+++ b/app/models/timeframe.js
@@ -1,0 +1,9 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class SubmissionModel extends Model {
+  @attr uri;
+  @attr('datetime') start;
+  @attr('datetime') end;
+
+  @belongsTo('event', { inverse: 'timeframes', async: true }) event;
+}

--- a/app/router.js
+++ b/app/router.js
@@ -25,6 +25,12 @@ Router.map(function () {
     this.route('meetings', function () {
       this.route('new');
     });
+    this.route('verenigingsloket', function () {
+      this.route('te-behandelen');
+      this.route('in-behandeling');
+      this.route('behandeld');
+      this.route('te-behandelen-awv');
+    });
     this.route('irg-archive');
   });
   this.route('mock-login');

--- a/app/routes/inbox/verenigingsloket/behandeld.js
+++ b/app/routes/inbox/verenigingsloket/behandeld.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class InboxVerenigingsloketBehandeldRoute extends Route {
+  @service store;
+
+  queryParams = {
+    pageSize: { refreshModel: false },
+    page: { refreshModel: false },
+    sort: { refreshModel: false },
+    filter: { refreshModel: false },
+    status: { refreshModel: true },
+  };
+}

--- a/app/routes/inbox/verenigingsloket/in-behandeling.js
+++ b/app/routes/inbox/verenigingsloket/in-behandeling.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class InboxVerenigingsloketInBehandelingRoute extends Route {
+  @service store;
+
+  queryParams = {
+    pageSize: { refreshModel: false },
+    page: { refreshModel: false },
+    sort: { refreshModel: false },
+    filter: { refreshModel: false },
+    status: { refreshModel: true },
+  };
+}

--- a/app/routes/inbox/verenigingsloket/index.js
+++ b/app/routes/inbox/verenigingsloket/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class InboxIndexRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.transitionTo('inbox.verenigingsloket.te-behandelen');
+  }
+}

--- a/app/routes/inbox/verenigingsloket/te-behandelen-awv.js
+++ b/app/routes/inbox/verenigingsloket/te-behandelen-awv.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class InboxVerenigingsloketTeBehandelenAWVRoute extends Route {
+  @service store;
+
+  queryParams = {
+    pageSize: { refreshModel: false },
+    page: { refreshModel: false },
+    sort: { refreshModel: false },
+    filter: { refreshModel: false },
+    status: { refreshModel: true },
+  };
+}

--- a/app/routes/inbox/verenigingsloket/te-behandelen.js
+++ b/app/routes/inbox/verenigingsloket/te-behandelen.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class InboxVerenigingsloketTeBehandelenRoute extends Route {
+  @service store;
+
+  queryParams = {
+    pageSize: { refreshModel: false },
+    page: { refreshModel: false },
+    sort: { refreshModel: false },
+    filter: { refreshModel: false },
+  };
+}

--- a/app/services/verenigingsloket.js
+++ b/app/services/verenigingsloket.js
@@ -1,0 +1,77 @@
+import Service, { service } from '@ember/service';
+import { task } from 'ember-concurrency';
+
+/**
+ * A number, or a string containing a number.
+ * @typedef {('te-behandelen'|'in-behandeling'|'behandeld'|'te-behandelen-awv')} AanvraagStatus
+ */
+
+/**
+ * @typedef Aanvraag
+ * @type {object}
+ * @property {AanvraagStatus} status
+ * @property {string} title
+ * @property {Date} createdOn
+ */
+/**
+ * @type {Aanvraag[]}
+ */
+export default class VerenigingsloketService extends Service {
+  @service store;
+
+  get sampleData() {
+    return [
+      this.store.createRecord('aanvraag-verenigingsloket', {
+        title: 'Veldrit Oudenaarde',
+        createdOn: new Date(),
+        status: 'te-behandelen',
+      }),
+      this.store.createRecord('aanvraag-verenigingsloket', {
+        title: 'Koers Waregem',
+        createdOn: new Date(),
+        status: 'te-behandelen',
+      }),
+      this.store.createRecord('aanvraag-verenigingsloket', {
+        title: 'MTB Ronse',
+        createdOn: new Date(),
+        status: 'te-behandelen',
+      }),
+      this.store.createRecord('aanvraag-verenigingsloket', {
+        title: 'Koers Oostakker',
+        createdOn: new Date(),
+        status: 'in-behandeling',
+      }),
+      this.store.createRecord('aanvraag-verenigingsloket', {
+        title: 'Gravel Meise',
+        createdOn: new Date(),
+        status: 'in-behandeling',
+      }),
+      this.store.createRecord('aanvraag-verenigingsloket', {
+        title: 'MTB Antwerpen',
+        createdOn: new Date(),
+        status: 'in-behandeling',
+      }),
+      this.store.createRecord('aanvraag-verenigingsloket', {
+        title: 'Koers Gent',
+        createdOn: new Date(),
+        status: 'behandeld',
+      }),
+      this.store.createRecord('aanvraag-verenigingsloket', {
+        title: 'Veldrit Aalst',
+        createdOn: new Date(),
+        status: 'behandeld',
+      }),
+      this.store.createRecord('aanvraag-verenigingsloket', {
+        title: 'MTB Eeklo',
+        createdOn: new Date(),
+        status: 'te-behandelen-awv',
+      }),
+    ];
+  }
+
+  fetch = task(async ({ status, title = '' }) => {
+    return this.sampleData.filter((aanvraag) => {
+      return aanvraag.title.includes(title) && aanvraag.status === status;
+    });
+  });
+}

--- a/app/templates/inbox.hbs
+++ b/app/templates/inbox.hbs
@@ -30,7 +30,14 @@
               <AuNavigationLink @route='inbox.verenigingsloket'>
                 <AuIcon @icon='message' @alignment='left' />
                 <span>Aanvragen verenigingsloket</span>
-                <AuBadge @number={{4}} @size='small' @skin="border" class="au-u-margin-left-tiny"/>
+                {{#if this.newSubmissionCount.value}}
+                  <AuBadge
+                    @number={{this.newSubmissionCount.value}}
+                    @size='small'
+                    @skin='border'
+                    class='au-u-margin-left-tiny'
+                  />
+                {{/if}}
               </AuNavigationLink>
             </li>
             {{#if this.model.length}}

--- a/app/templates/inbox.hbs
+++ b/app/templates/inbox.hbs
@@ -26,6 +26,13 @@
                 </AuNavigationLink>
               </li>
             {{/if}}
+            <li class='au-c-list-navigation__item'>
+              <AuNavigationLink @route='inbox.verenigingsloket'>
+                <AuIcon @icon='message' @alignment='left' />
+                <span>Aanvragen verenigingsloket</span>
+                <AuBadge @number={{4}} @size='small' @skin="border" class="au-u-margin-left-tiny"/>
+              </AuNavigationLink>
+            </li>
             {{#if this.model.length}}
               <li class='au-c-list-navigation__item'>
                 <AuNavigationLink @route='inbox.irg-archive'>

--- a/app/templates/inbox/verenigingsloket.hbs
+++ b/app/templates/inbox/verenigingsloket.hbs
@@ -11,7 +11,9 @@
       @route='inbox.verenigingsloket.te-behandelen'
     >
       Te behandelen
-      <AuBadge @number={{4}} @size='small' />
+      {{#if this.newSubmissionCount.value}}
+        <AuBadge @number={{this.newSubmissionCount.value}} @size='small' />
+      {{/if}}
     </AuLink>
   </Tab>
   <Tab>
@@ -28,11 +30,11 @@
       Behandeld
     </AuLink>
   </Tab>
-  <Tab>
+  {{!-- <Tab>
     <AuLink @route='inbox.verenigingsloket.te-behandelen-awv'>
       Door te sturen naar AWV
       <AuBadge @number={{2}} @size='small' />
     </AuLink>
-  </Tab>
+  </Tab> --}}
 </AuTabs>
 {{outlet}}

--- a/app/templates/inbox/verenigingsloket.hbs
+++ b/app/templates/inbox/verenigingsloket.hbs
@@ -1,0 +1,38 @@
+{{page-title 'Aanvragen verenigingsloket'}}
+
+<AuToolbar @size='large' as |Group|>
+  <Group>
+    <AuHeading @level={{1}} @skin={{2}}>Aanvragen verenigingsloket</AuHeading>
+  </Group>
+</AuToolbar>
+<AuTabs as |Tab|>
+  <Tab>
+    <AuLink
+      @route='inbox.verenigingsloket.te-behandelen'
+    >
+      Te behandelen
+      <AuBadge @number={{4}} @size='small' />
+    </AuLink>
+  </Tab>
+  <Tab>
+    <AuLink
+      @route='inbox.verenigingsloket.in-behandeling'
+    >
+      In behandeling
+    </AuLink>
+  </Tab>
+  <Tab>
+    <AuLink
+      @route='inbox.verenigingsloket.behandeld'
+    >
+      Behandeld
+    </AuLink>
+  </Tab>
+  <Tab>
+    <AuLink @route='inbox.verenigingsloket.te-behandelen-awv'>
+      Door te sturen naar AWV
+      <AuBadge @number={{2}} @size='small' />
+    </AuLink>
+  </Tab>
+</AuTabs>
+{{outlet}}

--- a/app/templates/inbox/verenigingsloket/behandeld.hbs
+++ b/app/templates/inbox/verenigingsloket/behandeld.hbs
@@ -2,6 +2,9 @@
   @content={{this.data.value}}
   @isLoading={{or this.updateFilter.isRunning this.data.isLoading}}
   @noDataMessage='Geen aanvragen gevonden'
+  @sort={{this.sort}}
+  @page={{this.page}}
+  @size={{this.pageSize}}
   as |table|
 >
   <table.menu as |menu|>
@@ -22,32 +25,43 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field='title'
+        @field=':no-case:case.event.title'
         @currentSorting={{this.sort}}
         @label='Titel'
       />
       <AuDataTableThSortable
-        @field='organizer'
+        @field=':no-case:applicant.name'
         @currentSorting={{this.sort}}
         @label='Organisator'
       />
       <AuDataTableThSortable
-        @field='createdOn'
+        @field='date'
         @currentSorting={{this.sort}}
         @label='Aangemaakt op'
       />
+      <AuDataTableThSortable
+        @field=':no-case:editorDocument.title'
+        @currentSorting={{this.sort}}
+        @label='Agendapunt'
+      />
     </c.header>
-    <c.body as |aanvraag|>
+    <c.body as |submission|>
       <td>
         <AuLink @skin='primary'>
-          {{aanvraag.title}}
+          {{submission.case.event.title}}
         </AuLink>
       </td>
       <td>
-        {{aanvraag.organizer}}
+        {{submission.applicant.name}}
       </td>
       <td>
-        {{detailed-date aanvraag.createdOn}}
+        {{detailed-date submission.date}}
+      </td>
+      <td>
+        <AgendaPuntLink
+          @documentContainer={{submission.editorDocument.documentContainer}}
+          @readOnly={{false}}
+        />
       </td>
     </c.body>
   </table.content>

--- a/app/templates/inbox/verenigingsloket/behandeld.hbs
+++ b/app/templates/inbox/verenigingsloket/behandeld.hbs
@@ -25,9 +25,9 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field=':no-case:case.event.title'
+        @field=':no-case:case.event.description'
         @currentSorting={{this.sort}}
-        @label='Titel'
+        @label='Beschrijving'
       />
       <AuDataTableThSortable
         @field=':no-case:applicant.name'
@@ -48,7 +48,7 @@
     <c.body as |submission|>
       <td>
         <AuLink @skin='primary'>
-          {{submission.case.event.title}}
+          {{submission.case.event.description}}
         </AuLink>
       </td>
       <td>

--- a/app/templates/inbox/verenigingsloket/behandeld.hbs
+++ b/app/templates/inbox/verenigingsloket/behandeld.hbs
@@ -1,0 +1,54 @@
+<AuDataTable
+  @content={{this.data.value}}
+  @isLoading={{or this.updateFilter.isRunning this.data.isLoading}}
+  @noDataMessage='Geen aanvragen gevonden'
+  as |table|
+>
+  <table.menu as |menu|>
+    <menu.general>
+      <AuToolbar class='au-o-box' @size='large' as |Group|>
+        <Group class='au-c-toolbar__group--center au-u-hide-on-print'>
+          <AuInput
+            @icon='search'
+            @iconAlignment='right'
+            value={{this.filter}}
+            placeholder='Zoek op titel aanvraag'
+            {{on 'input' (perform this.updateFilter)}}
+          />
+        </Group>
+      </AuToolbar>
+    </menu.general>
+  </table.menu>
+  <table.content as |c|>
+    <c.header>
+      <AuDataTableThSortable
+        @field='title'
+        @currentSorting={{this.sort}}
+        @label='Titel'
+      />
+      <AuDataTableThSortable
+        @field='organizer'
+        @currentSorting={{this.sort}}
+        @label='Organisator'
+      />
+      <AuDataTableThSortable
+        @field='createdOn'
+        @currentSorting={{this.sort}}
+        @label='Aangemaakt op'
+      />
+    </c.header>
+    <c.body as |aanvraag|>
+      <td>
+        <AuLink @skin='primary'>
+          {{aanvraag.title}}
+        </AuLink>
+      </td>
+      <td>
+        {{aanvraag.organizer}}
+      </td>
+      <td>
+        {{detailed-date aanvraag.createdOn}}
+      </td>
+    </c.body>
+  </table.content>
+</AuDataTable>

--- a/app/templates/inbox/verenigingsloket/in-behandeling.hbs
+++ b/app/templates/inbox/verenigingsloket/in-behandeling.hbs
@@ -2,6 +2,9 @@
   @content={{this.data.value}}
   @isLoading={{or this.updateFilter.isRunning this.data.isLoading}}
   @noDataMessage='Geen aanvragen gevonden'
+  @sort={{this.sort}}
+  @page={{this.page}}
+  @size={{this.pageSize}}
   as |table|
 >
   <table.menu as |menu|>
@@ -22,32 +25,43 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field='title'
+        @field=':no-case:case.event.title'
         @currentSorting={{this.sort}}
         @label='Titel'
       />
       <AuDataTableThSortable
-        @field='organizer'
+        @field=':no-case:applicant.name'
         @currentSorting={{this.sort}}
         @label='Organisator'
       />
       <AuDataTableThSortable
-        @field='createdOn'
+        @field='date'
         @currentSorting={{this.sort}}
         @label='Aangemaakt op'
       />
+      <AuDataTableThSortable
+        @field=':no-case:editorDocument.title'
+        @currentSorting={{this.sort}}
+        @label='Agendapunt'
+      />
     </c.header>
-    <c.body as |aanvraag|>
+    <c.body as |submission|>
       <td>
         <AuLink @skin='primary'>
-          {{aanvraag.title}}
+          {{submission.case.event.title}}
         </AuLink>
       </td>
       <td>
-        {{aanvraag.organizer}}
+        {{submission.applicant.name}}
       </td>
       <td>
-        {{detailed-date aanvraag.createdOn}}
+        {{detailed-date submission.date}}
+      </td>
+      <td>
+        <AgendaPuntLink
+          @documentContainer={{submission.editorDocument.documentContainer}}
+          @readOnly={{false}}
+        />
       </td>
     </c.body>
   </table.content>

--- a/app/templates/inbox/verenigingsloket/in-behandeling.hbs
+++ b/app/templates/inbox/verenigingsloket/in-behandeling.hbs
@@ -25,9 +25,9 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field=':no-case:case.event.title'
+        @field=':no-case:case.event.description'
         @currentSorting={{this.sort}}
-        @label='Titel'
+        @label='Beschrijving'
       />
       <AuDataTableThSortable
         @field=':no-case:applicant.name'
@@ -48,7 +48,7 @@
     <c.body as |submission|>
       <td>
         <AuLink @skin='primary'>
-          {{submission.case.event.title}}
+          {{submission.case.event.description}}
         </AuLink>
       </td>
       <td>

--- a/app/templates/inbox/verenigingsloket/in-behandeling.hbs
+++ b/app/templates/inbox/verenigingsloket/in-behandeling.hbs
@@ -1,0 +1,54 @@
+<AuDataTable
+  @content={{this.data.value}}
+  @isLoading={{or this.updateFilter.isRunning this.data.isLoading}}
+  @noDataMessage='Geen aanvragen gevonden'
+  as |table|
+>
+  <table.menu as |menu|>
+    <menu.general>
+      <AuToolbar class='au-o-box' @size='large' as |Group|>
+        <Group class='au-c-toolbar__group--center au-u-hide-on-print'>
+          <AuInput
+            @icon='search'
+            @iconAlignment='right'
+            value={{this.filter}}
+            placeholder='Zoek op titel aanvraag'
+            {{on 'input' (perform this.updateFilter)}}
+          />
+        </Group>
+      </AuToolbar>
+    </menu.general>
+  </table.menu>
+  <table.content as |c|>
+    <c.header>
+      <AuDataTableThSortable
+        @field='title'
+        @currentSorting={{this.sort}}
+        @label='Titel'
+      />
+      <AuDataTableThSortable
+        @field='organizer'
+        @currentSorting={{this.sort}}
+        @label='Organisator'
+      />
+      <AuDataTableThSortable
+        @field='createdOn'
+        @currentSorting={{this.sort}}
+        @label='Aangemaakt op'
+      />
+    </c.header>
+    <c.body as |aanvraag|>
+      <td>
+        <AuLink @skin='primary'>
+          {{aanvraag.title}}
+        </AuLink>
+      </td>
+      <td>
+        {{aanvraag.organizer}}
+      </td>
+      <td>
+        {{detailed-date aanvraag.createdOn}}
+      </td>
+    </c.body>
+  </table.content>
+</AuDataTable>

--- a/app/templates/inbox/verenigingsloket/te-behandelen-awv.hbs
+++ b/app/templates/inbox/verenigingsloket/te-behandelen-awv.hbs
@@ -25,9 +25,9 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field=':no-case:case.event.title'
+        @field=':no-case:case.event.description'
         @currentSorting={{this.sort}}
-        @label='Titel'
+        @label='Beschrijving'
       />
       <AuDataTableThSortable
         @field=':no-case:applicant.name'
@@ -43,7 +43,7 @@
     <c.body as |submission|>
       <td>
         <AuLink @skin='primary'>
-          {{submission.case.event.title}}
+          {{submission.case.event.description}}
         </AuLink>
       </td>
       <td>

--- a/app/templates/inbox/verenigingsloket/te-behandelen-awv.hbs
+++ b/app/templates/inbox/verenigingsloket/te-behandelen-awv.hbs
@@ -2,6 +2,9 @@
   @content={{this.data.value}}
   @isLoading={{or this.updateFilter.isRunning this.data.isLoading}}
   @noDataMessage='Geen aanvragen gevonden'
+  @sort={{this.sort}}
+  @page={{this.page}}
+  @size={{this.pageSize}}
   as |table|
 >
   <table.menu as |menu|>
@@ -22,32 +25,32 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field='title'
+        @field=':no-case:case.event.title'
         @currentSorting={{this.sort}}
         @label='Titel'
       />
       <AuDataTableThSortable
-        @field='organizer'
+        @field=':no-case:applicant.name'
         @currentSorting={{this.sort}}
         @label='Organisator'
       />
       <AuDataTableThSortable
-        @field='createdOn'
+        @field='date'
         @currentSorting={{this.sort}}
         @label='Aangemaakt op'
       />
     </c.header>
-    <c.body as |aanvraag|>
+    <c.body as |submission|>
       <td>
         <AuLink @skin='primary'>
-          {{aanvraag.title}}
+          {{submission.case.event.title}}
         </AuLink>
       </td>
       <td>
-        {{aanvraag.organizer}}
+        {{submission.applicant.name}}
       </td>
       <td>
-        {{detailed-date aanvraag.createdOn}}
+        {{detailed-date submission.date}}
       </td>
     </c.body>
   </table.content>

--- a/app/templates/inbox/verenigingsloket/te-behandelen-awv.hbs
+++ b/app/templates/inbox/verenigingsloket/te-behandelen-awv.hbs
@@ -1,0 +1,54 @@
+<AuDataTable
+  @content={{this.data.value}}
+  @isLoading={{or this.updateFilter.isRunning this.data.isLoading}}
+  @noDataMessage='Geen aanvragen gevonden'
+  as |table|
+>
+  <table.menu as |menu|>
+    <menu.general>
+      <AuToolbar class='au-o-box' @size='large' as |Group|>
+        <Group class='au-c-toolbar__group--center au-u-hide-on-print'>
+          <AuInput
+            @icon='search'
+            @iconAlignment='right'
+            value={{this.filter}}
+            placeholder='Zoek op titel aanvraag'
+            {{on 'input' (perform this.updateFilter)}}
+          />
+        </Group>
+      </AuToolbar>
+    </menu.general>
+  </table.menu>
+  <table.content as |c|>
+    <c.header>
+      <AuDataTableThSortable
+        @field='title'
+        @currentSorting={{this.sort}}
+        @label='Titel'
+      />
+      <AuDataTableThSortable
+        @field='organizer'
+        @currentSorting={{this.sort}}
+        @label='Organisator'
+      />
+      <AuDataTableThSortable
+        @field='createdOn'
+        @currentSorting={{this.sort}}
+        @label='Aangemaakt op'
+      />
+    </c.header>
+    <c.body as |aanvraag|>
+      <td>
+        <AuLink @skin='primary'>
+          {{aanvraag.title}}
+        </AuLink>
+      </td>
+      <td>
+        {{aanvraag.organizer}}
+      </td>
+      <td>
+        {{detailed-date aanvraag.createdOn}}
+      </td>
+    </c.body>
+  </table.content>
+</AuDataTable>

--- a/app/templates/inbox/verenigingsloket/te-behandelen.hbs
+++ b/app/templates/inbox/verenigingsloket/te-behandelen.hbs
@@ -25,9 +25,9 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field=':no-case:case.event.title'
+        @field=':no-case:case.event.description'
         @currentSorting={{this.sort}}
-        @label='Titel'
+        @label='Beschrijving'
       />
       <AuDataTableThSortable
         @field=':no-case:applicant.name'
@@ -44,7 +44,7 @@
     <c.body as |submission|>
       <td>
         <AuLink @skin='primary'>
-          {{submission.case.event.title}}
+          {{submission.case.event.description}}
         </AuLink>
       </td>
       <td>

--- a/app/templates/inbox/verenigingsloket/te-behandelen.hbs
+++ b/app/templates/inbox/verenigingsloket/te-behandelen.hbs
@@ -2,6 +2,9 @@
   @content={{this.data.value}}
   @isLoading={{or this.updateFilter.isRunning this.data.isLoading}}
   @noDataMessage='Geen aanvragen gevonden'
+  @sort={{this.sort}}
+  @page={{this.page}}
+  @size={{this.pageSize}}
   as |table|
 >
   <table.menu as |menu|>
@@ -22,32 +25,38 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field='title'
+        @field=':no-case:case.event.title'
         @currentSorting={{this.sort}}
         @label='Titel'
       />
       <AuDataTableThSortable
-        @field='organizer'
+        @field=':no-case:applicant.name'
         @currentSorting={{this.sort}}
         @label='Organisator'
       />
       <AuDataTableThSortable
-        @field='createdOn'
+        @field='date'
         @currentSorting={{this.sort}}
         @label='Aangemaakt op'
       />
+      <th></th>
     </c.header>
-    <c.body as |aanvraag|>
+    <c.body as |submission|>
       <td>
         <AuLink @skin='primary'>
-          {{aanvraag.title}}
+          {{submission.case.event.title}}
         </AuLink>
       </td>
       <td>
-        {{aanvraag.organizer}}
+        {{submission.applicant.name}}
       </td>
       <td>
-        {{detailed-date aanvraag.createdOn}}
+        {{detailed-date submission.date}}
+      </td>
+      <td>
+        <AuButton @skin="primary" @icon="plus">
+          Creëer agendapunt
+        </AuButton>
       </td>
     </c.body>
   </table.content>

--- a/app/templates/inbox/verenigingsloket/te-behandelen.hbs
+++ b/app/templates/inbox/verenigingsloket/te-behandelen.hbs
@@ -1,0 +1,54 @@
+<AuDataTable
+  @content={{this.data.value}}
+  @isLoading={{or this.updateFilter.isRunning this.data.isLoading}}
+  @noDataMessage='Geen aanvragen gevonden'
+  as |table|
+>
+  <table.menu as |menu|>
+    <menu.general>
+      <AuToolbar class='au-o-box' @size='large' as |Group|>
+        <Group class='au-c-toolbar__group--center au-u-hide-on-print'>
+          <AuInput
+            @icon='search'
+            @iconAlignment='right'
+            value={{this.filter}}
+            placeholder='Zoek op titel aanvraag'
+            {{on 'input' (perform this.updateFilter)}}
+          />
+        </Group>
+      </AuToolbar>
+    </menu.general>
+  </table.menu>
+  <table.content as |c|>
+    <c.header>
+      <AuDataTableThSortable
+        @field='title'
+        @currentSorting={{this.sort}}
+        @label='Titel'
+      />
+      <AuDataTableThSortable
+        @field='organizer'
+        @currentSorting={{this.sort}}
+        @label='Organisator'
+      />
+      <AuDataTableThSortable
+        @field='createdOn'
+        @currentSorting={{this.sort}}
+        @label='Aangemaakt op'
+      />
+    </c.header>
+    <c.body as |aanvraag|>
+      <td>
+        <AuLink @skin='primary'>
+          {{aanvraag.title}}
+        </AuLink>
+      </td>
+      <td>
+        {{aanvraag.organizer}}
+      </td>
+      <td>
+        {{detailed-date aanvraag.createdOn}}
+      </td>
+    </c.body>
+  </table.content>
+</AuDataTable>


### PR DESCRIPTION
This PR includes the initial implementation of the 'verenigingsloket' page. 
It contains 4 sections:
- 'te-behandelen'
- 'in-behandeling'
- 'behandeld'
- 'te-behandelen-awv'

TODOS:
- [x] Wire up with ember-data (that code is now in comments) + finish up ember-data model
- [ ] Creation of editor-document based on 'aanvraag'
- [x] Check if voting works correctly
- [ ] (optional) an 'aanvraag' detail page
- [ ] Implement send to 'AWV' button
- [x] Implement pagination (kinda get this for free with the ember-data impl)